### PR TITLE
daily perf tests instead of twice weekly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,9 +4,9 @@ name: Performance-Fourfront
 
 # Controls when the action will run. 
 on:
-  # Scheduled Monday and Thursday 7am ET / 11am UTC
+  # Scheduled daily 7am EST / 11am UTC
   schedule:
-    - cron: "0 11 * * 1,4"
+    - cron: "0 11 * * *"
   # Also can be run manually
   workflow_dispatch:
 


### PR DESCRIPTION
Daily perf tests instead of twice weekly (M/R). This will give us more data points on potential perf regressions on staging through the week.